### PR TITLE
docs: add GitHub achievement roadmap

### DIFF
--- a/ACHIEVEMENTS.md
+++ b/ACHIEVEMENTS.md
@@ -1,0 +1,21 @@
+# GitHub Achievement Roadmap
+
+This repo tracks the GitHub profile achievements that can be earned through real work.
+
+## Available targets
+
+| Achievement | Status | Real path |
+| --- | --- | --- |
+| Pull Shark | In progress | Keep opening useful PRs that get merged in public repositories. |
+| YOLO | In progress | Merge a small, owned PR without review when the change is low risk. |
+| Quickdraw | In progress | Resolve a tiny, valid issue shortly after opening it. |
+| Starstruck | Needs audience | Ship useful public projects and earn at least 16 stars on one repository. |
+| Galaxy Brain | Needs community | Answer GitHub Discussions and have maintainers mark answers as accepted. |
+| Pair Extraordinaire | Needs collaborator | Co-author commits with another GitHub user on PRs that get merged. |
+| Public Sponsor | Manual | Sponsor an open source maintainer through GitHub Sponsors. |
+
+## Notes
+
+- Achievements can take time to appear after the qualifying event.
+- Retired achievements, like Arctic Code Vault Contributor and Mars 2020 Helicopter Contributor, cannot be earned anymore.
+- The goal is to earn badges through useful work, not duplicate PRs or noisy issues.


### PR DESCRIPTION
## Summary
- add a concise roadmap for GitHub profile achievements
- separate realistic badges from badges that require community activity or manual sponsorship
- keep the profile README visual untouched

Closes #1